### PR TITLE
Reintroduced Button functionality

### DIFF
--- a/Core/ButtonState.h
+++ b/Core/ButtonState.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Buttons.h"
+
+class ButtonState
+{
+private:
+    const Buttons previous;
+    const Buttons current;
+  
+public:
+    inline ButtonState(Buttons current) :
+		previous(), current(current)
+	{
+	}
+	
+    inline ButtonState(Buttons previous, Buttons current) :
+		previous(previous), current(current)
+	{
+	}
+
+    inline Buttons GetPrevious(void) const
+    {
+        return this->previous;
+    }
+
+    inline Buttons GetCurrent(void) const
+    {
+        return this->current;
+    }
+
+    inline bool IsHeld(const Buttons buttons) const
+	{
+		return AllFlagsSet(this->current, buttons);
+	}
+	
+    inline bool IsPressed(const Buttons buttons) const
+	{
+		return AnyFlagsClear(this->previous, buttons)
+			&& AllFlagsSet(this->current, buttons);
+	}
+	
+    inline bool IsReleased(const Buttons buttons) const
+	{
+		return AllFlagsSet(this->previous, buttons)
+			&& AnyFlagsClear(this->current, buttons);
+	}
+};

--- a/Core/Buttons.h
+++ b/Core/Buttons.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <stdint.h>
+#include "core.h"
+
+enum class Buttons : uint8_t
+{
+	None = 0,
+	Left = LEFT_BUTTON,
+	Right = RIGHT_BUTTON,
+	Up =  UP_BUTTON,
+	Down = DOWN_BUTTON,
+	A = A_BUTTON,
+	B = B_BUTTON,
+};
+
+inline Buttons operator ~ (const Buttons buttons)
+{
+	return Buttons(~static_cast<uint8_t>(buttons));
+}
+
+inline Buttons operator & (const Buttons left, const Buttons right)
+{
+	return Buttons(static_cast<uint8_t>(left) & static_cast<uint8_t>(right));
+}
+
+inline Buttons & operator &= (Buttons & left, const Buttons right)
+{
+	return (left = left & right);
+}
+
+inline Buttons operator | (const Buttons left, const Buttons right)
+{
+	return Buttons(static_cast<uint8_t>(left) | static_cast<uint8_t>(right));
+}
+
+inline Buttons & operator |= (Buttons & left, const Buttons right)
+{
+	return (left = left | right);
+}
+
+inline Buttons operator ^ (const Buttons left, const Buttons right)
+{
+	return Buttons(static_cast<uint8_t>(left) ^ static_cast<uint8_t>(right));
+}
+
+inline Buttons & operator ^= (Buttons & left, const Buttons right)
+{
+	return (left = left ^ right);
+}
+
+inline bool AllFlagsSet(const Buttons buttons, const Buttons flags)
+{
+	return ((buttons & flags) == flags);
+}
+
+inline bool AnyFlagsSet(const Buttons buttons, const Buttons flags)
+{
+	return ((buttons & flags) != Buttons::None);
+}
+
+inline bool AllFlagsClear(const Buttons buttons, const Buttons flags)
+{
+	return ((buttons & flags) == Buttons::None);
+}
+
+inline bool AnyFlagsClear(const Buttons buttons, const Buttons flags)
+{
+	return ((buttons & flags) != flags);
+}


### PR DESCRIPTION
I really wanted `buttonSet.HasAllFlagsSet(flags)` and `buttonSet.HasAllFlagsClear(flags)` style functionality, but `AllFlagsSet(buttonSet, flags)` and `AllFlagsClear(buttonSet, flags)` will have to suffice.

`ButtonState`'s utility functions are now defined in terms of `AllFlagsSet` and `AnyFlagsClear` such that:
- `IsPressed` returns true only when any of the flags were previously clear and all of the currently set
- `IsReleased` returns true only when all of the flags were previously set and any of the currently clear
